### PR TITLE
Add search by id and  by name endpoints

### DIFF
--- a/app/apis/dao/author_dao.py
+++ b/app/apis/dao/author_dao.py
@@ -1,0 +1,24 @@
+from app.database.models.author import AuthorModel
+from typing import List
+
+
+class AuthorDAO:
+    @staticmethod
+    def find_author_by_id(id: int) -> 'AuthorModel':
+        """
+        Search author by id.
+        :param id: id of the author : int
+        :return: Author with the given id (or None)
+        """
+        return AuthorModel.query.get(id)
+
+    @staticmethod
+    def find_authors_by_name(name: str) -> List['AuthorModel']:
+        """
+        Search author by names (if author name contain `name` string)
+        :param name: name (or part of it): <str>
+        :return: List of AuthorModel object which name contains the given term
+        """
+        return AuthorModel.query.filter(AuthorModel.name.contains(name))
+
+

--- a/app/apis/models/author.py
+++ b/app/apis/models/author.py
@@ -1,5 +1,6 @@
 from flask_restplus import fields, Model
 
+
 def add_models_to_namespace(api_namespace):
     api_namespace.models[add_author_model.name] = add_author_model
 

--- a/app/apis/models/user.py
+++ b/app/apis/models/user.py
@@ -1,8 +1,10 @@
 from flask_restplus import fields, Model
 
+
 def add_models_to_namespace(api_namespace):
     api_namespace.models[register_user_model.name] = register_user_model
     api_namespace.models[login_user_model.name] = login_user_model
+
 
 register_user_model = Model(
     "Fields needed for user registration",
@@ -11,7 +13,8 @@ register_user_model = Model(
         "username": fields.String(required=True, description="Username of user"),
         "email": fields.String(required=True, description="Email of user"),
         "password": fields.String(required=True, description="Password of user"),
-        "terms_and_conditions_checked": fields.Boolean(required=True, description="Wether terms and conditions are checked"),
+        "terms_and_conditions_checked": fields.Boolean(required=True,
+                                                       description="Wether terms and conditions are checked"),
     }
 )
 

--- a/app/mappers/author_mapper.py
+++ b/app/mappers/author_mapper.py
@@ -1,0 +1,36 @@
+"""
+Mapping from model object to representation object"
+"""
+from typing import List
+
+from app.database.models.author import AuthorModel
+
+
+def map_to_dto(author: 'AuthorModel'):
+    """
+    :param author: Author object
+    :return: corresponding response made by mapping object to DTO
+    {
+    id: <section id>
+    name: "<section title>",
+    profile_image: "<image link>"
+    }
+    """
+    return author.json() if author else None
+
+
+def map_to_dto_list(authors: List['AuthorModel']):
+    """
+    :param authors: list of Author objects
+    :return: corresponding response list made by mapping objects to DTOs
+    {
+    id: <section id>
+    name: "<section title>",
+    profile_image: "<image link>"
+    }
+    """
+    author_repr_list = []
+    for author in authors:
+        author_repr_list.append(map_to_dto(author))
+    return author_repr_list
+


### PR DESCRIPTION
### Description

Added two endpoints in the `author` API actions:
1. search user by id -> returns corresponding author DTO or null if not found
2. search users by name -> performs substring search and returns a list of author DTO objects or an empty list if there is no user which name satisfies the string search.

Fixes  #16 

### Type of Change:
- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)


### How Has This Been Tested?
Manually tested (through Postman).  Endpoints to test out:
1. `/author/<id>`
2. `/author/<string:name>` or `/author/q?name=<string:name>`

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
