### PR TITLE
Removed authentication token requirement from GET /video/latest

### DIFF
--- a/app/api/controllers/video.py
+++ b/app/api/controllers/video.py
@@ -18,11 +18,6 @@ add_models_to_namespace(video_ns)
 
 @video_ns.route("/latest")
 class VideoLibrary(Resource):
-    @video_ns.doc(
-        params={
-            "authorization": {"in": "header", "description": "An authorization token"}
-        }
-    )
     def get(self):
         with open("./content/latests.json") as f:
             return json.loads(f.read())

--- a/app/api/controllers/video.py
+++ b/app/api/controllers/video.py
@@ -18,7 +18,6 @@ add_models_to_namespace(video_ns)
 
 @video_ns.route("/latest")
 class VideoLibrary(Resource):
-    @token_required
     @video_ns.doc(
         params={
             "authorization": {"in": "header", "description": "An authorization token"}


### PR DESCRIPTION
### Description
This PR removes the authentication token requirement from GET /video/latest endpoint.

Fixes #52 

### Type of Change:
**Delete irrelevant options.**

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)



### How Has This Been Tested?
I tried multiple GET requests to /video/latest endpoint and it no more requires auth token. It is returning data as expected.
![stem-video-latest](https://user-images.githubusercontent.com/54268438/106793997-2d7cd400-667e-11eb-80da-2080a41f5a92.gif)



### Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project


**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings
