### PR TITLE
Feat: Add POST category sections endpoint

### DIFF
--- a/app/api/controllers/category.py
+++ b/app/api/controllers/category.py
@@ -65,12 +65,12 @@ class CategorySection(Resource):
             return validation_result, 400
         section_ids = data["sections"]
         sections = SectionDAO.find_sections_by_ids(section_ids)
-        note = None
+        note = ""
         if sections.count() != len(section_ids):
             note = "Not all sections are valid/existing!"
         all_sections_added = CategoryDAO.add_category_sections(category, sections)
         if not all_sections_added:
-            note = "Duplicate category sections detected are they were not added!"
+            note += " Duplicate category sections detected are they were not added!"
         response = {"message": "Category sections added successfully."}, 201
         if note:
             response = {"message": note}, 201

--- a/app/api/controllers/category.py
+++ b/app/api/controllers/category.py
@@ -1,9 +1,16 @@
 from flask import request
 from flask_restplus import Namespace, Resource
+
+from app.api.models.category import *
 from app.database.models.category import CategoryModel
 from app.api.middlewares.auth import token_required
+from app.utils.messages import RESOURCE_NOT_FOUND
+from ..dao.category_dao import CategoryDAO
+from ..dao.section_dao import SectionDAO
+from ..validations.category import validate_category_sections_data
 
-category_ns = Namespace("category", description="Category Details")
+category_ns = Namespace("categories", description="Category Details")
+add_models_to_namespace(category_ns)
 
 
 @category_ns.route("/")
@@ -28,9 +35,9 @@ class Category(Resource):
 
         return {"message": "Category added"}, 201
 
+
 @category_ns.route("/all")
 class AllCategories(Resource):
-
     def get(self):
         category_models = CategoryModel.query.all()
         result = list()
@@ -38,3 +45,33 @@ class AllCategories(Resource):
             result.append(category.json())
         return {"categories": result}, 200
 
+
+@category_ns.route("/<int:id>/sections")
+class CategorySection(Resource):
+    @token_required
+    @category_ns.expect(add_category_sections)
+    @category_ns.doc(
+        params={
+            "authorization": {"in": "header", "description": "An authorization token"}
+        }
+    )
+    def post(self, id):
+        category = CategoryDAO.find_category_by_id(id)
+        if not category:
+            return RESOURCE_NOT_FOUND, 404
+        data = request.json
+        validation_result = validate_category_sections_data(data)
+        if validation_result:
+            return validation_result, 400
+        section_ids = data["sections"]
+        sections = SectionDAO.find_sections_by_ids(section_ids)
+        note = None
+        if sections.count() != len(section_ids):
+            note = "Not all sections are valid/existing!"
+        all_sections_added = CategoryDAO.add_category_sections(category, sections)
+        if not all_sections_added:
+            note = "Duplicate category sections detected are they were not added!"
+        response = {"message": "Category sections added successfully."}, 201
+        if note:
+            response = {"message": note}, 201
+        return response

--- a/app/api/controllers/section.py
+++ b/app/api/controllers/section.py
@@ -7,7 +7,11 @@ from app.api.validations.section import *
 from app.api.dao.section_dao import SectionDAO
 from app.api.dao.category_dao import CategoryDAO
 from app.api.mappers.section_mapper import *
-from app.utils.messages import SECTION_ALREADY_EXISTS, SECTION_TITLE_NOT_UPDATED, RESOURCE_NOT_FOUND
+from app.utils.messages import (
+    SECTION_ALREADY_EXISTS,
+    SECTION_TITLE_NOT_UPDATED,
+    RESOURCE_NOT_FOUND,
+)
 from app.api.middlewares.auth import token_required
 
 section_ns = Namespace("sections", description="Section Details")
@@ -39,7 +43,6 @@ class Section(Resource):
         except SQLAlchemyError as e:
             return {"message": f"Data cannot be persisted. Original error: {e}"}, 500
         return map_to_dto(section), 201
-
 
 
 @section_ns.route("/<int:id>")

--- a/app/api/dao/category_dao.py
+++ b/app/api/dao/category_dao.py
@@ -1,4 +1,6 @@
 from app.database.models.category import CategoryModel
+from flask_sqlalchemy import BaseQuery
+from typing import List
 
 
 class CategoryDAO:
@@ -37,3 +39,12 @@ class CategoryDAO:
         if category is None:
             category = CategoryDAO.create_category(title)
         return category
+
+    @staticmethod
+    def add_category_sections(category, sections: BaseQuery) -> bool:
+        non_existing_category_sections = []
+        for section in sections:
+            if section not in category.section:
+                non_existing_category_sections.append(section)
+        category.add_sections(non_existing_category_sections)
+        return len(non_existing_category_sections) == sections.count()

--- a/app/api/dao/section_dao.py
+++ b/app/api/dao/section_dao.py
@@ -15,7 +15,6 @@ class SectionDAO:
         return section
 
     @staticmethod
-
     def find_section_by_id(id: int) -> "SectionModel":
         """
         Find section that has the given id (if any).
@@ -54,4 +53,3 @@ class SectionDAO:
     @staticmethod
     def update_section(section, **kwargs):
         return section.update(**kwargs)
-

--- a/app/api/models/category.py
+++ b/app/api/models/category.py
@@ -1,0 +1,13 @@
+from flask_restplus import Model, fields
+
+
+def add_models_to_namespace(api_namespace):
+    api_namespace.models[add_category_sections.name] = add_category_sections
+
+
+add_category_sections = Model(
+    "Fields needed for adding new category sections instances",
+    {
+        "sections": fields.List(fields.Integer(), description="list of section ids"),
+    },
+)

--- a/app/api/models/section.py
+++ b/app/api/models/section.py
@@ -16,7 +16,5 @@ add_section_model = Model(
 
 update_section_model = Model(
     "Fields needed for updating an existing section",
-    {
-        "title": fields.String(required=True, description="section title")
-    },
+    {"title": fields.String(required=True, description="section title")},
 )

--- a/app/api/validations/category.py
+++ b/app/api/validations/category.py
@@ -1,0 +1,3 @@
+def validate_category_sections_data(data):
+    if "sections" not in data:
+        return {"message": "List of sections must be provided."}

--- a/app/api/validations/section.py
+++ b/app/api/validations/section.py
@@ -4,9 +4,11 @@ def validate_section_data(data):
     if "category" not in data:
         return {"message": "Category title must be provided."}, 400
 
-      
+
 def validate_updatable_section_data(data):
     if "title" not in data:
         return {"message": "Title of the section must be provided."}, 400
     if len(data.keys()) > 1:
-        return {"message": "Inappropriate data structure. Only title should be provided."}, 400
+        return {
+            "message": "Inappropriate data structure. Only title should be provided."
+        }, 400

--- a/app/database/models/category.py
+++ b/app/database/models/category.py
@@ -27,6 +27,12 @@ class CategoryModel(db.Model):
         db.session.add(self)
         db.session.commit()
 
+    def add_sections(self, sections) -> None:
+        """Add category section instance"""
+        self.section.extend(sections)
+        db.session.add(self)
+        db.session.commit()
+
     def add_category_section(self, section) -> None:
         self.section.append(section)
         db.session.add(self)

--- a/app/database/models/section.py
+++ b/app/database/models/section.py
@@ -36,7 +36,6 @@ class SectionModel(db.Model):
         db.session.commit()
         return self
 
-
     def add_video(self, video: "VideoModel") -> None:
         self.videos.append(video)
         db.session.add(self)

--- a/app/utils/messages.py
+++ b/app/utils/messages.py
@@ -17,5 +17,6 @@ SECTION_ALREADY_EXISTS = {"message": "Section with the given title already exist
 RESOURCE_NOT_FOUND = {"message": "resource with the given identifier was not found."}
 
 # BAD REQUEST messages
-SECTION_TITLE_NOT_UPDATED = {"message": "The new section title is the same as the old one."}
-
+SECTION_TITLE_NOT_UPDATED = {
+    "message": "The new section title is the same as the old one."
+}


### PR DESCRIPTION
### Description
Added endpoint for creating category sections instances.
URL: `/categories/{id}/sections`
Request payload:
```json
{
  "sections": [
    1,2,3
  ]
}
```
Validates:
1) structure of the request body
2) if the category exists
3) takes only existing sections (with existing ids)
4) does not add duplicate instances (previously created)
Fixes #54.

### Type of Change:
- Code
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
Tested through Swagger UI.
Case 1: category does not exist
![image](https://user-images.githubusercontent.com/16724101/107064412-c2491400-67db-11eb-9618-257116c10e75.png)
Case 2: invalid request body
![image](https://user-images.githubusercontent.com/16724101/107064516-e1e03c80-67db-11eb-96eb-4188bbb89a41.png)
Case 3: some sections do not exist
![image](https://user-images.githubusercontent.com/16724101/107065207-ca558380-67dc-11eb-804a-bc07be6be596.png)
Case 4: duplicate category sections
![image](https://user-images.githubusercontent.com/16724101/107064685-18b65280-67dc-11eb-9528-392c74b0e366.png)
Case 5: added successfully
![image](https://user-images.githubusercontent.com/16724101/107065021-90847d00-67dc-11eb-8e72-29810ee492fd.png)
Case 6: Case 3 + 4
![image](https://user-images.githubusercontent.com/16724101/107065307-e8bb7f00-67dc-11eb-82f0-f8667001f6fa.png)


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
