### PR TITLE
feat: Create endpoint to get video stream url

### DIFF
--- a/app/api/controllers/video.py
+++ b/app/api/controllers/video.py
@@ -226,7 +226,6 @@ class VideoSections(Resource):
 
 @video_ns.route("/stream/<string:videoId>/<int:format>")
 class GetVideoStream(Resource):
-    @token_required
     @video_ns.doc(
         params={
             "authorization": {"in": "header", "description": "An authorization token"}

--- a/app/api/controllers/video.py
+++ b/app/api/controllers/video.py
@@ -231,7 +231,6 @@ class GetVideoStream(Resource):
         params={
             "authorization": {"in": "header", "description": "An authorization token"}
         }
-    )
     def get(self, videoId, format):
         try:
             info = youtube_dl_extract_info(videoId)

--- a/app/api/controllers/video.py
+++ b/app/api/controllers/video.py
@@ -227,7 +227,6 @@ class VideoSections(Resource):
 @video_ns.route("/stream/<string:videoId>/<int:format>")
 class GetVideoStream(Resource):
             "authorization": {"in": "header", "description": "An authorization token"}
-        }
     def get(self, videoId, format):
         try:
             info = youtube_dl_extract_info(videoId)

--- a/app/api/controllers/video.py
+++ b/app/api/controllers/video.py
@@ -226,7 +226,6 @@ class VideoSections(Resource):
 
 @video_ns.route("/stream/<string:videoId>/<int:format>")
 class GetVideoStream(Resource):
-            "authorization": {"in": "header", "description": "An authorization token"}
     def get(self, videoId, format):
         try:
             info = youtube_dl_extract_info(videoId)

--- a/app/api/controllers/video.py
+++ b/app/api/controllers/video.py
@@ -226,7 +226,6 @@ class VideoSections(Resource):
 
 @video_ns.route("/stream/<string:videoId>/<int:format>")
 class GetVideoStream(Resource):
-    @video_ns.doc(
             "authorization": {"in": "header", "description": "An authorization token"}
         }
     def get(self, videoId, format):

--- a/app/api/controllers/video.py
+++ b/app/api/controllers/video.py
@@ -227,7 +227,6 @@ class VideoSections(Resource):
 @video_ns.route("/stream/<string:videoId>/<int:format>")
 class GetVideoStream(Resource):
     @video_ns.doc(
-        params={
             "authorization": {"in": "header", "description": "An authorization token"}
         }
     def get(self, videoId, format):

--- a/app/utils/youtube_dl.py
+++ b/app/utils/youtube_dl.py
@@ -1,0 +1,21 @@
+import youtube_dl
+
+
+def youtube_dl_extract_info(video_id):
+    ydl = youtube_dl.YoutubeDL()
+
+    full_video_url = "%s%s" % ("https://www.youtube.com/watch?v=", video_id)
+
+    with ydl:
+        result = ydl.extract_info(full_video_url, download=False)
+    return result
+
+
+def youtube_dl_extract_format(info, format_id):
+    result = []
+    for i in info["formats"]:
+        if int(i["format_id"]) == format_id:
+            result.append(i["url"])
+    if not result:
+        result.append({"message": f"Requested format '{format_id}' is not available"})
+    return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,4 @@ SQLAlchemy==1.3.18
 uritemplate==3.0.1
 urllib3==1.25.10
 Werkzeug==0.16.1
+youtube_dl==2021.2.10


### PR DESCRIPTION
### Description

Created a GET endpoint to fetch the streamable URL of youtube video. Video id and required format need to pass in as URL params.
![image](https://user-images.githubusercontent.com/17108695/107802542-78d26900-6d87-11eb-9a6c-63643e5b8cd7.png)

Response Structure: 
```
{
  "stream": ["stream url"]
}
```

Fixes #50 

### Type of Change:

- Code
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
Tested through Swagger and Postman
![image](https://user-images.githubusercontent.com/17108695/107802927-f5654780-6d87-11eb-9e23-dfde695147e4.png)

![image](https://user-images.githubusercontent.com/17108695/107804712-3eb69680-6d8a-11eb-9337-f497252ece41.png)



### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
