### PR TITLE
Removed details from youtube payload

### DIFF
--- a/app/api/models/video.py
+++ b/app/api/models/video.py
@@ -35,15 +35,6 @@ add_video_model = Model(
     },
 )
 
-yt_video_section_field = Model(
-    "section field of add youtube video model",
-    {
-        "title": fields.String(required=True, description="section title"),
-        "category": fields.String(required=True, description="category title"),
-        "id": fields.String(required=True, description="existing section id"),
-    },
-)
-
 add_yt_video_model = Model(
     "Fields needed for adding new Youtube Video",
     {
@@ -51,7 +42,5 @@ add_yt_video_model = Model(
             description="YouTube video url",
             required=True,
         ),
-        "sections": fields.List(fields.Nested(yt_video_section_field)),
-        "authors": fields.List(fields.Integer(description="existing author id")),
     },
 )

--- a/app/api/validations/video.py
+++ b/app/api/validations/video.py
@@ -8,9 +8,7 @@ REQUIRED_FIELDS_MAP = {
     "date_published": "date of publishing",
     "source": "source",
     "channel": "channel",
-    "duration": "duration",
-    "category_sections": "category sections",
-    "authors": "authors",
+    "duration": "duration"
 }
 
 


### PR DESCRIPTION
### Description

To remove the details from the video/youtube/payload 

Fixes #72 

### Type of Change:
**Delete irrelevant options.**

- Code


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)



### How Has This Been Tested?
Tried passing a youtube video url and got the following response :
![stem-ytube-fix](https://user-images.githubusercontent.com/54268438/107838481-18194f80-6dcc-11eb-9aec-8c5770e188af.gif)



### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
