### PR TITLE
Fix endpoint response format

### DIFF
--- a/app/api/controllers/video.py
+++ b/app/api/controllers/video.py
@@ -170,7 +170,7 @@ class AddYoutubeVideo(Resource):
             )
 
         result["video"] = map_to_dto(video)
-        return {"123": response.json(), "result": result}, 200
+        return result, 200
 
 
 @video_ns.route("/<int:id>/sections")


### PR DESCRIPTION
### Description

In https://github.com/anitab-org/stem-diverse-tv/pull/119 I forgot to remove [extra code](https://github.com/anitab-org/stem-diverse-tv/pull/119/files#diff-70e879af50b7fbb05de0bb92f4e6bdb2b27053a2fcb5c7f99019019a88a07f67R173) from the response of the controller method. 

This PR fixes the wrong response format that was added in https://github.com/anitab-org/stem-diverse-tv/pull/119

### Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
